### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/ox-asciidoc.el
+++ b/ox-asciidoc.el
@@ -3,6 +3,8 @@
 ;; Copyright (C) 2013  Free Software Foundation, Inc.
 
 ;; Author: Yasushi SHOJI <yasushi.shoji@gmail.com>
+;; URL: https://github.com/yashi/org-asciidoc
+;; Package-Requires: ((org "8.2.5c"))
 ;; Keywords: org, asciidoc
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
When installing this package from [MELPA](http://melpa.milkbox.net/) (or any other ELPA repository in which it might be found) then `org` should also be installed. This commit adds the corresponding Package-Requires header to install `org`. Feel free to adjust the required version if desired.
