### PR TITLE
Add defcustom for generated file extension, manage toc

### DIFF
--- a/ox-asciidoc.el
+++ b/ox-asciidoc.el
@@ -509,7 +509,8 @@ be converted with AsciiDoc's image macro."
 	(email (org-asciidoc-info-get-with info :email))
         (date (org-asciidoc-info-get-with info :date))
         (docinfo (plist-get info :asciidoc-docinfo))
-	(latex-transcoder (plist-get info :asciidoc-latex)))
+	(latex-transcoder (plist-get info :asciidoc-latex))
+        (depth (plist-get info :with-toc)))
     (concat
      ;; The first line, title
      (format "= %s =\n" title)
@@ -528,6 +529,10 @@ be converted with AsciiDoc's image macro."
      ;; Add docinfo line if needed
      (when docinfo
        ":docinfo:\n")
+     (when depth
+       ":toc:\n")
+     (when (wholenump depth)
+       (format ":toclevels: %d\n" depth))
      (let ((get-latex-attr (intern-soft (format "org-asciidoc-latex-attr/%s" latex-transcoder))))
        (when (functionp get-latex-attr)
 	 (funcall get-latex-attr)))

--- a/ox-asciidoc.el
+++ b/ox-asciidoc.el
@@ -136,6 +136,11 @@ into the adoc document."
   :group 'org-export-asciidoc
   :type 'boolean)
 
+(defcustom org-asciidoc-file-extension ".adoc"
+  "Default extension of asciidoc generated file."
+  :group 'org-export-asciidoc
+  :type 'string)
+
 (defun org-asciidoc-identity (blob contents info)
   "Transcode BLOB element or object back into Org syntax.
 CONTENTS is its contents, as a string or nil.  INFO is ignored."
@@ -589,7 +594,7 @@ contents of hidden elements.
 
 Return output file name."
   (interactive)
-  (let ((outfile (org-export-output-file-name ".txt" subtreep)))
+  (let ((outfile (org-export-output-file-name org-asciidoc-file-extension subtreep)))
     (org-export-to-file 'asciidoc outfile async subtreep visible-only)))
 
 ;;;###autoload
@@ -601,7 +606,7 @@ is the property list for the given project.  PUB-DIR is the
 publishing directory.
 
 Return output file name."
-  (org-publish-org-to 'asciidoc filename ".txt" plist pub-dir))
+  (org-publish-org-to 'asciidoc filename org-asciidoc-file-extension plist pub-dir))
 
 (provide 'ox-asciidoc)
 

--- a/test-ox-asciidoc.el
+++ b/test-ox-asciidoc.el
@@ -50,11 +50,77 @@
 
    "= This is the title =
 John Smith
+:toc:
 
 ")
 
   (org-asciidoc-test-transcode-with-template
    "#+Title: This is the title
+#+AUTHOR: John Smith
+#+Date: 2001-01-01"
+
+   "= This is the title =
+John Smith
+2001-01-01
+:toc:
+
+")
+
+  (org-asciidoc-test-transcode-with-template
+   "#+Title: This is the title
+#+AUTHOR: John Smith
+#+Date: 2001-01-01
+#+options: asciidoc-latex:stem-latexmath"
+
+   "= This is the title =
+John Smith
+2001-01-01
+:toc:
+:stem: latexmath
+
+")
+
+  (org-asciidoc-test-transcode-with-template
+   "#+Title: This is the title
+#+AUTHOR: John Smith
+#+Date: 2001-01-01
+#+options: toc:4"
+
+   "= This is the title =
+John Smith
+2001-01-01
+:toc:
+:toclevels: 4
+
+")
+
+  (org-asciidoc-test-transcode-with-template
+   "#+Title: This is the title
+#+AUTHOR: John Smith
+#+Date: 2001-01-01
+#+options: toc:t"
+
+   "= This is the title =
+John Smith
+2001-01-01
+:toc:
+
+"))
+
+(ert-deftest test-org-asciidoc/title-without-toc ()
+  (org-asciidoc-test-transcode-with-template
+   "#+AUTHOR: John Smith
+#+Title: This is the title
+#+options: toc:nil"
+
+   "= This is the title =
+John Smith
+
+")
+
+  (org-asciidoc-test-transcode-with-template
+   "#+Title: This is the title
+#+options: toc:nil
 #+AUTHOR: John Smith
 #+Date: 2001-01-01"
 
@@ -68,7 +134,7 @@ John Smith
    "#+Title: This is the title
 #+AUTHOR: John Smith
 #+Date: 2001-01-01
-#+options: asciidoc-latex:stem-latexmath"
+#+options: asciidoc-latex:stem-latexmath toc:nil"
 
    "= This is the title =
 John Smith
@@ -81,7 +147,7 @@ John Smith
   (org-asciidoc-test-transcode-with-template
    "#+Title: This is the title
 #+AUTHOR: John Smith
-#+OPTIONS: asciidoc-docinfo:nil"
+#+OPTIONS: asciidoc-docinfo:nil toc:nil"
 
    "= This is the title =
 John Smith
@@ -91,7 +157,7 @@ John Smith
   (org-asciidoc-test-transcode-with-template
    "#+Title: This is the title
 #+AUTHOR: John Smith
-#+OPTIONS: asciidoc-docinfo:t"
+#+OPTIONS: asciidoc-docinfo:t toc:nil"
 
    "= This is the title =
 John Smith


### PR DESCRIPTION
- Add defcustom for generated file extension as consensus about what it should be doesn't exists,
- Add support for table of content and depth if specified.