### PR TITLE
org-asciidoc-link: Remove debug line

### DIFF
--- a/ox-asciidoc.el
+++ b/ox-asciidoc.el
@@ -475,7 +475,6 @@ Image files without description should be inlined, so they will
 be converted with AsciiDoc's image macro."
   (let ((type (org-element-property :type link))
 	(path (org-element-property :path link)))
-    (message (org-export-read-attribute :attr_asciidoc link))
     (cond
      ((and (not desc) (org-file-image-p path))
       (if (string= type "file")


### PR DESCRIPTION
Remove the debug line which most of the time prints empty lines.

This fixes #22 